### PR TITLE
Fix: Parse DB url & set, instead of establishing connection first

### DIFF
--- a/lib/grape/activerecord/activerecord.rb
+++ b/lib/grape/activerecord/activerecord.rb
@@ -14,8 +14,7 @@ module Grape
 
     # Connect to database with a DB URL. Example: "postgres://user:pass@localhost/db"
     def self.database_url=(url)
-      ::ActiveRecord::Base.establish_connection(url)
-      ::ActiveRecord::Base.configurations = {RACK_ENV.to_s => ::ActiveRecord::Base.connection.pool.spec.config}
+      self.database = ::ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver.new(url).to_hash
     end
 
     # Connect to database with a yml file. Example: "config/database.yml"


### PR DESCRIPTION
I ran into a bug where `rake db:create` couldn't create the database when `database_url` was used:

```bash
$ rake db:create
ActiveRecord::NoDatabaseError: Unknown database 'project_development'
```

Problem was that the connection was established first, the config set afterwards. This has to be swapped. Fix is to parse the URL first (re-using `::ActiveRecord::ConnectionAdapters::ConnectionSpecification::ConnectionUrlResolver`)  and set the config + establish connection afterwards
