### PR TITLE
Add to the docs an ActiveRecord gotcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ After loading your gems, tell `Grape::ActiveRecord` about your database config u
     Grape::ActiveRecord.configure_from_url! ENV['DATABASE_URL'] # e.g. postgres://user:pass@host/db
     Grape::ActiveRecord.configure_from_hash!(adapter: "postgresql", host: "localhost", database: "db", username: "user", password: "pass", encoding: "utf8", pool: 10, timeout: 5000)
 
+**Important note**: `configure_from_file!` won't work as expected if you have already `DATABASE_URL` set as part of your environment variables.
+This is because in ActiveRecord when that env variable is set it will merge its properties into the current connection configuration.
+
 #### 3. Enable ActiveRecord connection management
 
 This ActiveRecord middleware cleans up your database connections after each request. Add it to your `config.ru` file:


### PR DESCRIPTION
I was banging my head against the wall trying to figure out why my tests weren't running against my `test` DB. After some debugging the actual problem is that ActiveRecord always merges connection information from `ENV['DATABASE_URL']`. 

This means that if you have that env variable set, that will affect your connection properties defined as part of your `config/database.yml`.

As part of this PR I just updated the docs describing that behavior.